### PR TITLE
Feat/no flags

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -44,6 +44,10 @@ impl FromStr for ArgGraphFormat {
 #[derive(Parser, Debug)]
 #[command(author, about = "RDF conversion tool")]
 pub(crate) struct Args {
+    #[arg(long, help="Don't guess format based on file suffix.")]
+    pub(crate) no_guess: bool,
+    #[arg(long, help="Don't output the resulting graph (useful for checking validity of input).")]
+    pub(crate) no_warn: bool,
     #[arg(short, long, help = "Input RDF serialization format")]
     pub(crate) input_format: Option<ArgGraphFormat>,
     #[arg(
@@ -53,6 +57,6 @@ pub(crate) struct Args {
         help = "Output RDF serialization format"
     )]
     pub(crate) output_format: Option<ArgGraphFormat>,
-    #[arg(default_value = "-", help = "Input file. Use - for stdin.")]
+    #[arg(default_value = "-", help = "Input file. Omit or use - for stdin.")]
     pub(crate) input_file: Option<String>,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -47,7 +47,7 @@ pub(crate) struct Args {
     #[arg(long, help="Don't guess format based on file suffix.")]
     pub(crate) no_guess: bool,
     #[arg(long, help="Don't output the resulting graph (useful for checking validity of input).")]
-    pub(crate) no_warn: bool,
+    pub(crate) no_out: bool,
     #[arg(short, long, help = "Input RDF serialization format")]
     pub(crate) input_format: Option<ArgGraphFormat>,
     #[arg(


### PR DESCRIPTION
Add support for:

* `--no-guess`: Prevent automatic guessing of input format
* `--no-out`: Disable output, only parsing the input file for validation.