### PR TITLE
Improved docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+*
+!src/
+!Cargo.toml
+!Cargo.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,5 @@ COPY --from=builder \
 # Use unprivileged user
 USER rust:rust
 
-ENV PATH="/app/:${PATH}"
-ENTRYPOINT ["rdfpipe-rs"]
+ENTRYPOINT ["./rdfpipe-rs"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,23 +2,27 @@
 # cargo-chef to cache compiled dependencies and
 # minimize the size of the final image.
 
-# 1: Read code and write recipe file
-FROM rust AS planner
+ARG RUST_BASE=rust:1.74.0-slim-bookworm
+ARG RUNNER_BASE=gcr.io/distroless/cc-debian12
+ARG VERSION_BUILD=0.1.0
+
+### 1: Read code and write recipe file
+FROM ${RUST_BASE} AS planner
 WORKDIR /app
 RUN cargo install cargo-chef
 COPY . .
 RUN cargo chef prepare --recipe-path recipe.json
 
-# 2: Cache compiled dependencies for faster builds
-FROM rust AS cacher
+### 2: Cache compiled dependencies for faster builds
+FROM ${RUST_BASE} AS cacher
 WORKDIR /app
 RUN cargo install cargo-chef
 COPY --from=planner /app/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
 
 
-# 3: Build project, but reuse cached dependencies
-FROM rust AS builder
+### 3: Build project, but reuse cached dependencies
+FROM ${RUST_BASE} AS builder
 
 # Create unprivileged user
 ENV USER=rust
@@ -43,8 +47,14 @@ COPY --from=cacher /usr/local/cargo /usr/local/cargo
 RUN cargo build --release
 
 
-# 4: Copy required binaries into distroless runner
-FROM gcr.io/distroless/cc-debian12 AS runner
+### 4: Copy required binaries into distroless runner
+FROM ${RUNNER_BASE} AS runner
+
+# Add annotations
+LABEL org.opencontainers.image.source=https://github.com/SDSC-ORD/rdfpipe-rs
+LABEL org.opencontainers.image.description="Quickly convert between RDF file formats. A rust implementation of rdfpipe based on the sophia crate."
+LABEL org.opencontainers.image.licenses=GPL-3.0-or-later
+LABEL org.opencontainers.image.version ${VERSION_BUILD}
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,65 @@
-ARG BASE_IMAGE=ekidd/rust-musl-builder:latest
+# This Dockerfile uses a multi-stage build with
+# cargo-chef to cache compiled dependencies and
+# minimize the size of the final image.
 
-# Build environment
-FROM ${BASE_IMAGE} AS builder
+# 1: Read code and write recipe file
+FROM rust AS planner
+WORKDIR /app
+RUN cargo install cargo-chef
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
 
-# Add source code under new user
-ADD --chown=rust:rust . ./
+# 2: Cache compiled dependencies for faster builds
+FROM rust AS cacher
+WORKDIR /app
+RUN cargo install cargo-chef
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
+
+
+# 3: Build project, but reuse cached dependencies
+FROM rust AS builder
+
+# Create unprivileged user
+ENV USER=rust
+ENV UID=1001
+ 
+RUN adduser \
+    --disabled-password \
+    --gecos "" \
+    --home "/nonexistent" \
+    --shell "/sbin/nologin" \
+    --no-create-home \
+    --uid "${UID}" \
+    "${USER}"
+
+COPY . /app
+WORKDIR /app
+
+# Copy pre-built dependencies
+COPY --from=cacher /app/target target
+COPY --from=cacher /usr/local/cargo /usr/local/cargo
 
 RUN cargo build --release
 
-# Runner image
-FROM alpine:latest
-RUN apk --no-cache add ca-certificates
-COPY --from=builder \
-    /home/rust/src/target/x86_64-unknown-linux-musl/release/rdfpipe-rs \
-    /usr/local/bin/
 
-CMD /usr/local/rdfpipe-rs
+# 4: Copy required binaries into distroless runner
+FROM gcr.io/distroless/cc-debian12 AS runner
+
+WORKDIR /app
+
+# Import user files
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder /etc/group /etc/group
+COPY --from=builder /bin/sh /bin/sh
+
+# Import binary
+COPY --from=builder \
+    /app/target/release/rdfpipe-rs \
+    /app/rdfpipe-rs
+
+USER rust:rust
+
+ENV PATH="/app/:${PATH}"
+ENTRYPOINT ["rdfpipe-rs"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,13 +51,13 @@ WORKDIR /app
 # Import user files
 COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /etc/group /etc/group
-COPY --from=builder /bin/sh /bin/sh
 
 # Import binary
 COPY --from=builder \
     /app/target/release/rdfpipe-rs \
     /app/rdfpipe-rs
 
+# Use unprivileged user
 USER rust:rust
 
 ENV PATH="/app/:${PATH}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN cargo chef cook --release --recipe-path recipe.json
 FROM ${RUST_BASE} AS builder
 
 # Create unprivileged user
-ENV USER=rust
+ENV USER=appuser
 ENV UID=1001
  
 RUN adduser \
@@ -68,7 +68,7 @@ COPY --from=builder \
     /app/rdfpipe-rs
 
 # Use unprivileged user
-USER rust:rust
+USER appuser:appuser
 
 ENTRYPOINT ["./rdfpipe-rs"]
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ rdfpipe-rs is still missing the following features:
 
 * json-ld support
 * quad support (named graphs)
-* serializing prettified turtle.
 * `--ns` option for explicit namespace binding
 
 


### PR DESCRIPTION
This PR fixes and improves the Dockerfile as follows:
* Multi-stage build with [cargo chef](https://github.com/LukeMathWalker/cargo-chef)
  + Cargo-chef caches compiled dependencies in an intermediate layer. This makes `docker build` fast as long as dependencies do not change, because only the project code must be recompiled.
* Use [Google's debian "distroless" image](https://github.com/GoogleContainerTools/distroless) as the base layer for the runner layer. It is a stripped down linux system with libc (no package manager or anything)
  + This brings the image size down to 31MB
  + The image has very few vulnerabilities (trivy finds 13 low and 4 medium CVEs)
* Use an unprivileged user in the container