### PR TITLE
typo: git source repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ rdfpipe-rs is still missing the following features:
 The package must be compiled from source using [cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html):
 
 ```sh
-git clone https://github.com/cmdoret/rdfpipe-rs
+git clone https://github.com/sdsc-ordes/rdfpipe-rs
 cd rdfpipe-rs
 cargo build --release
 # executable binary located in ./target/release/rdfpipe-rs


### PR DESCRIPTION
source should be sdsc-ordes, not cmdoret - right? I cloned the repo and then realized it's a bit strange to be pulling from a non-existent repo (even if git correctly forwards the request to github.com/sdsc-ordes/rdfpipe-rs